### PR TITLE
Provide feature

### DIFF
--- a/ini-mode.el
+++ b/ini-mode.el
@@ -93,4 +93,5 @@ If `prog-mode' is defined, inherit from it."
 
 ;;;###autoload(add-to-list 'auto-mode-alist '("\\.ini\\'" . ini-mode))
 
+(provide 'ini-mode)
 ;;; ini-mode.el ends here


### PR DESCRIPTION
A library has to provide the matching feature to make it possible to `require` it.