### PR TITLE
Allow for ini files that have tabs or spaces preceeding key names.

### DIFF
--- a/ini-mode.el
+++ b/ini-mode.el
@@ -70,7 +70,7 @@
 (defvar ini-font-lock-keywords
   '(("^\\[\\(.*\\)\\]"
      (1 font-lock-function-name-face))
-    ("^\\([^ \t\n=]+\\) *="
+    ("^[ \t]*\\([^ \t\n=]+\\) *="
      (1 font-lock-variable-name-face)))
   "Highlight rules for `ini-mode'.")
 


### PR DESCRIPTION
This facilitates handling ini files as generated by `git config` which uses tabs to indent key names within sections.

Addresses Issue #5 .